### PR TITLE
Some improvements of the logLik method

### DIFF
--- a/R/SaemixObject.R
+++ b/R/SaemixObject.R
@@ -1129,74 +1129,69 @@ setMethod(f="plot",
 ####			Likelihood and tests		####
 ####################################################################################
 
-##' Extract likelihood from a saemixObject resulting from a call to saemix
+##' Extract likelihood from an SaemixObject resulting from a call to saemix
 ##'
-##' The likelihood in saemix can be computed by one of three methods: linearisation (linearisation of the model), importance sampling (stochastic integration) and gaussian quadrature (numerical integration). The linearised likelihood is obtained as a byproduct of the computation of the Fisher Information Matrix (argument FIM=TRUE in the options given to the saemix function).
-##' If no method argument is given, this function will attempt to extract the likelihood computed by importance sampling (method="is"), unless the object contains the likelihood computed by linearisation, in which case the function will extract this component instead.
-##' If the requested likelihood is not present in the object, it will be computed and aded to the object before returning.
+##' The likelihood in saemix can be computed by one of three methods: linearisation (linearisation of the model), importance sampling (stochastic integration) and gaussian quadrature (numerical integration). The linearised likelihood is obtained as a byproduct of the computation of the Fisher Information Matrix (fim=TRUE in the control options given to the saemix function).
+##' If no method argument is given, this function will attempt to extract the likelihood computed by importance sampling (method="is").
+##' If the requested likelihood is not present in the object and the argument add=TRUE (the default), it will be computed and added to the object in addition to returning the computed value. If it is not present and add=FALSE, an error message is given.
 ##'
 ##' @name logLik
 ##' @aliases AIC.SaemixObject BIC.SaemixObject logLik.SaemixObject
 ##'
 ##' @param object name of an SaemixObject object
-##' @param method character string, one of c("is","lin","gq"), to select one of the available approximations to the log-likelihood (is: Importance Sampling; lin: linearisation and gq: Gaussian Quadrature). See documentation for details
+##' @param method character string, one of c("is","lin","gq"), to select one of the available approximations to the log-likelihood (is: Importance Sampling; lin: linearisation and gq: Gaussian Quadrature).
+##' @param add boolean, specifying if the requested value should be added to the object in case it is not present. The default is TRUE.
 ##' @param ... additional arguments
 ##' @param k numeric, the penalty per parameter to be used; the default k = 2 is the classical AIC
-##' @return Returns the selected statistical criterion (log-likelihood, AIC, BIC) extracted from the SaemixObject, computed with the 'method' argument if given (defaults to IS).
+##' @return Returns the selected statistical criterion (log-likelihood, AIC, BIC) extracted from the SaemixObject, computed with the 'method' argument if given.
 ##' @references Comets  E, Lavenu A, Lavielle M. Parameter estimation in nonlinear mixed effect models using saemix, an R implementation of the SAEM algorithm. Journal of Statistical Software 80, 3 (2017), 1-41.
-#' 
-#' Kuhn E, Lavielle M. Maximum likelihood estimation in nonlinear mixed effects models. Computational Statistics and Data Analysis 49, 4 (2005), 1020-1038.
+##' 
+##' Kuhn E, Lavielle M. Maximum likelihood estimation in nonlinear mixed effects models. Computational Statistics and Data Analysis 49, 4 (2005), 1020-1038.
 ##' 
 ##' Comets E, Lavenu A, Lavielle M. SAEMIX, an R version of the SAEM algorithm. 20th meeting of the Population Approach Group in Europe, Athens, Greece (2011), Abstr 2173.
 #' @author Emmanuelle Comets \email{emmanuelle.comets@@inserm.fr}
 #' @author Audrey Lavenu
 #' @author Marc Lavielle.
-#' @seealso \code{\link{AIC}},\code{\link{BIC}}, \code{\link{saemixControl}}, \code{\link{saemix}}
+#' @seealso [AIC], [BIC], [saemixControl], [saemix], [llis.saemix]], [llgq.saemix], [fim.saemix]
 #' @docType methods
 #' @keywords methods
 #' @export
 
 ## log-likelihood for SaemixObject objects
-logLik.SaemixObject<- function(object, method="is", ...) {
-#   args1<-match.call(expand.dots=TRUE)
-#   i1<-match("method",names(args1))
-#   if(!is.na(i1)) {
-#     str1<-as.character(args1[[i1]])
-#     if(str1 %in% c("is","lin","gq")) method<-str1
-#   } else {
-#     if(length(object@results@ll.is)!=0 | length(object@results@ll.lin)==0) method<-"is" else method<-"lin"
-#   }
-  # Compute the requested LL if not present
+logLik.SaemixObject<- function(object, method=c("is","lin","gq"), add=TRUE, ...) {
+  method <- match.arg(method)
   namObj<-deparse(substitute(object))
-  if(method=="is" & length(object@results@ll.is)==0) {
-    object<-llis.saemix(object)
-    assign(namObj,object,envir=parent.frame())
+
+  if (add) {
+    # Compute the requested LL if not present
+    if(method=="is" & length(object@results@ll.is)==0) {
+      object<-llis.saemix(object)
+      assign(namObj,object,envir=parent.frame())
+    }
+    if(method=="gq" & length(object@results@ll.gq)==0) {
+      object<-llgq.saemix(object)
+      assign(namObj,object,envir=parent.frame())
+    }
+    if(method=="lin" & length(object@results@ll.lin)==0) {
+      object<-fim.saemix(object)
+      assign(namObj,object,envir=parent.frame())
+    }
+  } else {
+    # OR: return if desired LL has not been computed
+    if(method=="gq" & length(object@results@ll.gq)==0) {
+      message("The log-likelihood by Gaussian Quadrature has not yet been computed.")
+      invisible()
+    }
+    if(method=="is" & length(object@results@ll.is)==0) {
+      message("The log-likelihood by Importance Sampling has not yet been computed.")
+      invisible()
+    }
+    if(method=="lin" & length(object@results@ll.lin)==0) {
+      message("The log-likelihood by linearisation has not yet been computed.")
+      invisible()
+    }
   }
-  if(method=="gq" & length(object@results@ll.gq)==0) {
-    object<-llgq.saemix(object)
-    assign(namObj,object,envir=parent.frame())
-  }
-  if(method=="lin" & length(object@results@ll.lin)==0) {
-    object<-fim.saemix(object)
-    assign(namObj,object,envir=parent.frame())
-  }
-  # OR: return if desired LL has not been computed
-  #     if(method=="gq" & length(object@results@ll.gq)==0) {
-  #     	cat("The log-likelihood by Gaussian Quadrature has not yet been computed.\n")
-  #     	invisible(NULL)
-  #     }
-  #     if(method=="is" & length(object@results@ll.is)==0) {
-  #     	cat("The log-likelihood by Importance Sampling has not yet been computed.\n")
-  #     	invisible(NULL)
-  #     }
-  #     if(method=="lin" & length(object@results@ll.lin)==0) {
-  #     	cat("The log-likelihood by linearisation has not yet been computed.\n")
-  #     	invisible(NULL)
-  #     }
   val<-switch(method,is=object@results@ll.is,lin=object@results@ll.lin, gq=object@results@ll.gq)
-  res<-paste(format(val,digits=2,nsmall=2)," (df=",object@results@npar.est,")", sep="")
-  res<-matrix(res,dimnames=list(paste("LL by",method)," "))
-  print(res)
   attr(val, "nall") <- object@data@N
   attr(val, "nobs") <- object@data@ntot.obs
   attr(val, "df") <- object@results@npar.est

--- a/man/logLik.Rd
+++ b/man/logLik.Rd
@@ -6,9 +6,9 @@
 \alias{logLik.SaemixObject}
 \alias{AIC.SaemixObject}
 \alias{BIC.SaemixObject}
-\title{Extract likelihood from a saemixObject resulting from a call to saemix}
+\title{Extract likelihood from an SaemixObject resulting from a call to saemix}
 \usage{
-\method{logLik}{SaemixObject}(object, method = "is", ...)
+\method{logLik}{SaemixObject}(object, method = c("is", "lin", "gq"), add = TRUE, ...)
 
 \method{AIC}{SaemixObject}(object, ..., k = 2)
 
@@ -17,19 +17,21 @@
 \arguments{
 \item{object}{name of an SaemixObject object}
 
-\item{method}{character string, one of c("is","lin","gq"), to select one of the available approximations to the log-likelihood (is: Importance Sampling; lin: linearisation and gq: Gaussian Quadrature). See documentation for details}
+\item{method}{character string, one of c("is","lin","gq"), to select one of the available approximations to the log-likelihood (is: Importance Sampling; lin: linearisation and gq: Gaussian Quadrature).}
+
+\item{add}{boolean, specifying if the requested value should be added to the object in case it is not present. The default is TRUE.}
 
 \item{...}{additional arguments}
 
 \item{k}{numeric, the penalty per parameter to be used; the default k = 2 is the classical AIC}
 }
 \value{
-Returns the selected statistical criterion (log-likelihood, AIC, BIC) extracted from the SaemixObject, computed with the 'method' argument if given (defaults to IS).
+Returns the selected statistical criterion (log-likelihood, AIC, BIC) extracted from the SaemixObject, computed with the 'method' argument if given.
 }
 \description{
-The likelihood in saemix can be computed by one of three methods: linearisation (linearisation of the model), importance sampling (stochastic integration) and gaussian quadrature (numerical integration). The linearised likelihood is obtained as a byproduct of the computation of the Fisher Information Matrix (argument FIM=TRUE in the options given to the saemix function).
-If no method argument is given, this function will attempt to extract the likelihood computed by importance sampling (method="is"), unless the object contains the likelihood computed by linearisation, in which case the function will extract this component instead.
-If the requested likelihood is not present in the object, it will be computed and aded to the object before returning.
+The likelihood in saemix can be computed by one of three methods: linearisation (linearisation of the model), importance sampling (stochastic integration) and gaussian quadrature (numerical integration). The linearised likelihood is obtained as a byproduct of the computation of the Fisher Information Matrix (fim=TRUE in the control options given to the saemix function).
+If no method argument is given, this function will attempt to extract the likelihood computed by importance sampling (method="is").
+If the requested likelihood is not present in the object and the argument add=TRUE (the default), it will be computed and added to the object in addition to returning the computed value. If it is not present and add=FALSE, an error message is given.
 }
 \references{
 Comets  E, Lavenu A, Lavielle M. Parameter estimation in nonlinear mixed effect models using saemix, an R implementation of the SAEM algorithm. Journal of Statistical Software 80, 3 (2017), 1-41.
@@ -39,7 +41,7 @@ Kuhn E, Lavielle M. Maximum likelihood estimation in nonlinear mixed effects mod
 Comets E, Lavenu A, Lavielle M. SAEMIX, an R version of the SAEM algorithm. 20th meeting of the Population Approach Group in Europe, Athens, Greece (2011), Abstr 2173.
 }
 \seealso{
-\code{\link{AIC}},\code{\link{BIC}}, \code{\link{saemixControl}}, \code{\link{saemix}}
+\link{AIC}, \link{BIC}, \link{saemixControl}, \link{saemix}, \link{llis.saemix}], \link{llgq.saemix}, \link{fim.saemix}
 }
 \author{
 Emmanuelle Comets \email{emmanuelle.comets@inserm.fr}

--- a/man/logLik.Rd
+++ b/man/logLik.Rd
@@ -8,18 +8,16 @@
 \alias{BIC.SaemixObject}
 \title{Extract likelihood from an SaemixObject resulting from a call to saemix}
 \usage{
-\method{logLik}{SaemixObject}(object, method = c("is", "lin", "gq"), add = TRUE, ...)
+\method{logLik}{SaemixObject}(object, method = c("is", "lin", "gq"), ...)
 
-\method{AIC}{SaemixObject}(object, ..., k = 2)
+\method{AIC}{SaemixObject}(object, method = c("is", "lin", "gq"), ..., k = 2)
 
-\method{BIC}{SaemixObject}(object, ...)
+\method{BIC}{SaemixObject}(object, method = c("is", "lin", "gq"), ...)
 }
 \arguments{
 \item{object}{name of an SaemixObject object}
 
 \item{method}{character string, one of c("is","lin","gq"), to select one of the available approximations to the log-likelihood (is: Importance Sampling; lin: linearisation and gq: Gaussian Quadrature).}
-
-\item{add}{boolean, specifying if the requested value should be added to the object in case it is not present. The default is TRUE.}
 
 \item{...}{additional arguments}
 
@@ -31,7 +29,7 @@ Returns the selected statistical criterion (log-likelihood, AIC, BIC) extracted 
 \description{
 The likelihood in saemix can be computed by one of three methods: linearisation (linearisation of the model), importance sampling (stochastic integration) and gaussian quadrature (numerical integration). The linearised likelihood is obtained as a byproduct of the computation of the Fisher Information Matrix (fim=TRUE in the control options given to the saemix function).
 If no method argument is given, this function will attempt to extract the likelihood computed by importance sampling (method="is").
-If the requested likelihood is not present in the object and the argument add=TRUE (the default), it will be computed and added to the object in addition to returning the computed value. If it is not present and add=FALSE, an error message is given.
+If the requested likelihood is not present in the object, an error message is given.
 }
 \references{
 Comets  E, Lavenu A, Lavielle M. Parameter estimation in nonlinear mixed effect models using saemix, an R implementation of the SAEM algorithm. Journal of Statistical Software 80, 3 (2017), 1-41.

--- a/tests/testthat/setup_script.R
+++ b/tests/testthat/setup_script.R
@@ -1,0 +1,29 @@
+library(saemix)
+
+theo_data <- saemixData(name.data = theo.saemix,
+  header = TRUE, sep = " ", na = NA,
+  name.group = c("Id"), name.predictors = c("Dose", "Time"),
+  name.response = c("Concentration"), name.covariates = c("Weight","Sex"),
+  units = list(x = "hr", y = "mg/L", covariates = c("kg", "-")),
+  name.X = "Time")
+
+model1cpt<-function(psi, id, xidep) {
+  dose <- xidep[, 1]
+  tim  <- xidep[, 2]
+  ka   <- psi[id, 1]
+  V    <- psi[id, 2]
+  CL   <- psi[id, 3]
+  k    <- CL/V
+  ypred <- dose * ka/(V * (ka - k)) * (exp(- k * tim) - exp(- ka * tim))
+  return(ypred)
+}
+
+model_1cpt <- saemixModel(model = model1cpt,
+  description = "One-compartment model with first-order absorption, no covariate",
+  psi0 = matrix(c(1., 20, 0.5), ncol = 3, byrow = TRUE,
+    dimnames = list(NULL, c("ka", "V", "CL"))),
+  transform.par = c(1, 1, 1))
+
+saemix.options <- list(seed = 123456, save = FALSE, save.graphs = FALSE)
+
+theo_fit_1 <-saemix(model_1cpt, theo_data, saemix.options)

--- a/tests/testthat/test-logLik.R
+++ b/tests/testthat/test-logLik.R
@@ -1,0 +1,26 @@
+context("Extraction and calculation of diagnostic messages")
+
+test_that("Log-Likelihood, AIC and BIC can be extracted", {
+
+  ll_is <- logLik(theo_fit_1)
+  expect_equal(class(ll_is), "logLik")
+  expect_equal(round(as.numeric(ll_is), 2), -172.81)
+  expect_equal(attr(ll_is, "df"), 7)
+
+  AIC_is <- AIC(theo_fit_1)
+  expect_equal(round(AIC_is, 2), 359.63)
+
+  BIC_is <- BIC(theo_fit_1)
+  expect_equal(round(BIC_is, 2), 363.02)
+
+  ll_lin <- logLik(theo_fit_1, method = "lin")
+  expect_equal(round(as.numeric(ll_lin), 2), -171.98)
+
+  AIC_lin <- AIC(theo_fit_1, method = "lin")
+  expect_equal(round(AIC_lin, 2), 357.96)
+
+  BIC_lin <- BIC(theo_fit_1, method = "lin")
+  expect_equal(round(BIC_lin, 2), 361.35)
+
+  expect_error(ll_gq <- logLik(theo_fit_1, method = "gq"), "not yet.*computed")
+})


### PR DESCRIPTION
As this is an implementation of the logLik method of base R, and the
base method does not print anything except by the print method of its
return value of class 'logLik', I think this method should also not do any
printing on its own. Therefore this commit removes the corresponding
code.

Also, it is unconventional that the logLik method modifies its argument
in-place if the requested value is not present. Therefore, this commit
adds an option to turn this off. The commented out code after the
comment "OR: .." was used to provide the alternative, which is giving a
message and does not return anything.

In the seealso section, links to the functions that can be used to
add these missing likelihoods were added. In roxygen comments,
simple brackets can be used to specify those links which is much 
more readable than `\code{\link{xy}}`.

Also, match.arg() is used for the 'method' argument for easy argument
matching and validation.