### PR TITLE
Don't plot per default in llis.saemix. Fixes #8

### DIFF
--- a/R/compute_LL.R
+++ b/R/compute_LL.R
@@ -155,7 +155,13 @@ llis.saemix<-function(saemixObject) {
 	
 	x1<-MM*c(kmin:KM)
 	y1<-(-2)*LL[kmin:KM]
-	if(sum(!is.na(y1))) try(plot(x1,y1,type="l",xlab="Size of the Monte-Carlo sample", ylab="'-2xLog-Likelihood",main=tit)) else cat("Likelihood cannot be computed by Importance Sampling.\n")
+	if(sum(is.na(y1))) {
+		message("Likelihood cannot be computed by Importance Sampling.\n")
+	} else {
+		if (saemixObject["options"]$print.is) {
+			try(plot(x1,y1,type="l",xlab="Size of the Monte-Carlo sample", ylab="'-2xLog-Likelihood",main=tit))
+		}
+	}
 	saemixObject["results"]["LL"]<-c(LL)
 	saemixObject["results"]["ll.is"]<-LL[KM]
 	saemixObject["results"]["aic.is"]<-(-2)*saemixObject["results"]["ll.is"]+ 2*saemixObject["results"]["npar.est"]

--- a/tests/testthat/setup_script.R
+++ b/tests/testthat/setup_script.R
@@ -24,6 +24,7 @@ model_1cpt <- saemixModel(model = model1cpt,
     dimnames = list(NULL, c("ka", "V", "CL"))),
   transform.par = c(1, 1, 1))
 
-saemix.options <- list(seed = 123456, save = FALSE, save.graphs = FALSE)
+saemix.options <- list(seed = 123456, save = FALSE, save.graphs = FALSE,
+  displayProgress = FALSE)
 
 theo_fit_1 <-saemix(model_1cpt, theo_data, saemix.options)


### PR DESCRIPTION
Plotting can be triggered either by control option print.is of saemix,
which mentions plotting in the documentation, or by a call to
plot(object, plot.type = "likelihood").