### PR TITLE
Don't print covariate names while reading SaemixData

### DIFF
--- a/R/SaemixData.R
+++ b/R/SaemixData.R
@@ -719,7 +719,6 @@ setMethod("read",
   			object@units$covariates<-object@units$covariates[object@name.covariates %in% colnames(dat)]
   			object@name.covariates<-object@name.covariates[object@name.covariates %in% colnames(dat)]
   		}
-  		if(object@messages) print(object@name.covariates)
     }
     if(nchar(object@name.group)*length(object@name.predictors)*nchar(object@name.response)<=0) {
       stop("Please check the structure of the data file and provide information concerning which columns specify the group structure (ID), the predictors (eg dose, time) and the response (eg Y, conc). See documentation for automatic recognition of column names for these elements.\n")


### PR DESCRIPTION
Printing these in the read() method is irritating - printing the
covariate names in the print method is sufficient.