### PR TITLE
Fix the test for reading saemixData from file

### DIFF
--- a/tests/testthat/setup_script.R
+++ b/tests/testthat/setup_script.R
@@ -29,8 +29,6 @@ m_1cpt <- saemixModel(model = f_1cpt,
   transform.par = c(1, 1, 1),
   verbose = FALSE
 )
-saemix.options <- list(seed = 123456, save = FALSE, save.graphs = FALSE,
-  displayProgress = FALSE)
 
 m_1cpt_1_cov <- saemixModel(model = f_1cpt,
   description = "One-compartment model, clearance dependent on weight",

--- a/tests/testthat/test-saemixData.R
+++ b/tests/testthat/test-saemixData.R
@@ -1,7 +1,10 @@
 test_that("saemixData can read from a file and from a data frame passed to it", {
+  data(theo.saemix)
   expect_output(
     {
-      path <- system.file("testdata/theo.saemix.tab", package = "saemix")
+      path <- tempfile(fileext = ".tab")
+      write.table(theo.saemix, file = path,
+        quote = FALSE, sep = " ", row.names = FALSE)
       saemixData(path,
         header=TRUE,sep=" ",na=NA,
         name.group=c("Id"),name.predictors=c("Dose","Time"),
@@ -11,7 +14,6 @@ test_that("saemixData can read from a file and from a data frame passed to it", 
     "Reading.*successfully")
   expect_output(
     {
-      data(theo.saemix)
       saemixData(name.data=theo.saemix,header=TRUE,sep=" ",na=NA,
         name.group=c("Id"),name.predictors=c("Dose","Time"),
         name.response=c("Concentration"),name.covariates=c("Weight","Sex"),


### PR DESCRIPTION
The file that the test was using used to be located in the testdata/
folder, but has been removed at some point. Therefore we create a
temporary file in the test and read from there.

This pull request also removes some redundant code creating a list with saemix options.